### PR TITLE
1.1.2: Refactor string formatting and prompt generation logic

### DIFF
--- a/dnd/encounter.py
+++ b/dnd/encounter.py
@@ -88,7 +88,7 @@ class Encounter:
     @staticmethod
     def get_hit_points(combatant_name):
         while True:
-            hp = input("(Optional) Enter hit points for %s (y or x/y): " % combatant_name)
+            hp = input(f"(Optional) Enter hit points for {combatant_name} (y or x/y): ")
             if hp == '':
                 return 0, 0
             else:
@@ -103,14 +103,14 @@ class Encounter:
         monster_number = self.get_number(monster_name)
         if monster_number == 1:
             return [monster_name]
-        return ["%s (%s)" % (monster_name, COLORS[i]) for i in range(monster_number)]
+        return [f"{monster_name}, COLORS[{i}]" for i in range(monster_number)]
 
     @staticmethod
     def get_number(monster_name):
         monster_number = 0
         while 1 > monster_number or monster_number > len(COLORS):
             try:
-                monster_number = int(input("How many %s?: " % monster_name))
+                monster_number = int(input(f"How many {monster_name}?: "))
                 if monster_number > len(COLORS):
                     print("Come on, switch it up")
             except Exception:
@@ -122,7 +122,7 @@ class Encounter:
         initiative_bonus = None
         while initiative_bonus is None:
             try:
-                initiative_bonus = int(input("Enter initiative bonus for %s: " % monster_name))
+                initiative_bonus = int(input(f"Enter initiative bonus for {monster_name}: "))
             except Exception:
                 print("Try again")
         return initiative_bonus
@@ -221,7 +221,7 @@ class EncounterPlayer:
         switcher = OptionSwitcher(len(self.encounter.combatants), self.apply_healing, base_cases)
 
         clear()
-        self.print_healing_menu()
+        self.print_all_combatants_menu()
         callback = None
         while callback is None:
             option = input("Select a number to heal combatant, or go (b)ack: ")
@@ -235,26 +235,21 @@ class EncounterPlayer:
 
     def print_main_menu(self):
         for combatant in self.acted:
-            print("\N{CHECK MARK} %s" % combatant.name)
+            print(f"\N{CHECK MARK} {combatant}")
         print('')
         for i in range(len(self.ordered)):
-            print("%d. %s (%d/%d)" % (
-                i + 1,
-                self.ordered[i].name,
-                self.ordered[i].hit_points[0],
-                self.ordered[i].hit_points[1]
-            ))
+            print(f"{i + 1}. {self.ordered[i]}")
         print('')
         for combatant in self.encounter.combatants:
             if combatant.hit_points[0] == 0 and combatant.hit_points[1] > 0:
-                print("\N{CROSS MARK} %s" % combatant.name)
+                print(f"\N{CROSS MARK} {combatant}")
 
     def apply_damage(self, index):
         combatant = self.active[index]
         damage = -1
         while damage < 0:
             try:
-                damage = int(input("How much damage to %s?: " % combatant.name))
+                damage = int(input(f"How much damage to {combatant.name}?: "))
                 if damage > -1:
                     break
             except Exception:
@@ -271,19 +266,14 @@ class EncounterPlayer:
 
     def print_damage_menu(self):
         for i in range(len(self.active)):
-            print("%d. %s (%d/%d)" % (
-                i + 1,
-                self.active[i].name,
-                self.active[i].hit_points[0],
-                self.active[i].hit_points[1]
-            ))
+            print(f"{i + 1}. {self.active[i]}")
 
     def apply_healing(self, index):
         combatant = self.encounter.combatants[index]
         healing = -1
         while healing < 0:
             try:
-                healing = int(input("How many hit points to restore to %s?: " % combatant.name))
+                healing = int(input(f"How many hit points to restore to {combatant.name}?: "))
                 if healing > -1:
                     break
             except Exception:
@@ -294,14 +284,9 @@ class EncounterPlayer:
         self.active = [c for c in self.encounter.combatants if c.hit_points[0] > 0 or c.hit_points[1] == 0]
         return True
 
-    def print_healing_menu(self):
+    def print_all_combatants_menu(self):
         for i in range(len(self.encounter.combatants)):
-            print("%d. %s (%d/%d)" % (
-                i + 1,
-                self.encounter.combatants[i].name,
-                self.encounter.combatants[i].hit_points[0],
-                self.encounter.combatants[i].hit_points[1]
-            ))
+            print(f"{i + 1}. {self.encounter.combatants[i]}")
 
 
 class Combatant:
@@ -310,6 +295,10 @@ class Combatant:
         self.name = name
         self.initiative = initiative
         self.hit_points = hit_points
+
+    def __str__(self):
+        s = f"{self.name} ({self.hit_points[0]}/{self.hit_points[1]})"
+        return s
 
 
 class OptionSwitcher:

--- a/dnd/encounter.py
+++ b/dnd/encounter.py
@@ -203,14 +203,14 @@ class EncounterPlayer:
         base_cases = {
             "b": lambda: self.true()
         }
-        switcher = OptionSwitcher(len(self.active), self.apply_damage, base_cases)
+        callback_map = CallbackMap(self.active, self.apply_damage, base_cases)
 
         clear()
         self.print_damage_menu()
         callback = None
         while callback is None:
             option = input("Select a number to damage combatant, or go (b)ack: ")
-            callback = switcher.get(option)
+            callback = callback_map.get(option)
 
         return callback()
 
@@ -218,14 +218,14 @@ class EncounterPlayer:
         base_cases = {
             "b": lambda: self.true()
         }
-        switcher = OptionSwitcher(len(self.encounter.combatants), self.apply_healing, base_cases)
+        callback_map = CallbackMap(self.encounter.combatants, self.apply_healing, base_cases)
 
         clear()
         self.print_all_combatants_menu()
         callback = None
         while callback is None:
             option = input("Select a number to heal combatant, or go (b)ack: ")
-            callback = switcher.get(option)
+            callback = callback_map.get(option)
 
         return callback()
 
@@ -244,8 +244,7 @@ class EncounterPlayer:
             if combatant.hit_points[0] == 0 and combatant.hit_points[1] > 0:
                 print(f"\N{CROSS MARK} {combatant}")
 
-    def apply_damage(self, index):
-        combatant = self.active[index]
+    def apply_damage(self, combatant):
         damage = -1
         while damage < 0:
             try:
@@ -268,8 +267,7 @@ class EncounterPlayer:
         for i in range(len(self.active)):
             print(f"{i + 1}. {self.active[i]}")
 
-    def apply_healing(self, index):
-        combatant = self.encounter.combatants[index]
+    def apply_healing(self, combatant):
         healing = -1
         while healing < 0:
             try:

--- a/dnd/encounter.py
+++ b/dnd/encounter.py
@@ -320,4 +320,19 @@ class OptionSwitcher:
         return self.cases.get(case, None)
 
 
+class CallbackMap:
+    def __init__(self, options, action, base_cases=None, **kwargs):
+        if base_cases is None:
+            base_cases = dict()
+        if kwargs is None:
+            kwargs = dict()
+        cases = {}
+        for i in range(len(options)):
+            cases[str(i + 1)] = partial(action, options[i], **kwargs)
+        self.cases = {**cases, **base_cases}
+
+    def get(self, case):
+        return self.cases.get(case, None)
+
+
 main()

--- a/dnd/encounter.py
+++ b/dnd/encounter.py
@@ -299,25 +299,6 @@ class Combatant:
         return s
 
 
-class OptionSwitcher:
-
-    def __init__(self, num_options, action, base_cases=None):
-        if base_cases is None:
-            base_cases = dict()
-        self.action = action
-        self.cases = self.create_cases(num_options)
-        self.cases = {**self.cases, **base_cases}
-
-    def create_cases(self, num_options):
-        cases = {}
-        for i in range(num_options):
-            cases[str(i + 1)] = partial(self.action, i)
-        return cases
-
-    def get(self, case):
-        return self.cases.get(case, None)
-
-
 class CallbackMap:
     def __init__(self, options, action, base_cases=None, **kwargs):
         if base_cases is None:

--- a/dnd/encounter.py
+++ b/dnd/encounter.py
@@ -173,7 +173,7 @@ class EncounterPlayer:
             "d": lambda: self.damage_prompt(),
             "h": lambda: self.heal_prompt()
         }
-        switcher = OptionSwitcher(len(self.ordered), self.take_turn, base_cases)
+        callback_map = CallbackMap(range(len(self.ordered)), self.take_turn, base_cases)
 
         clear()
         self.print_main_menu()
@@ -183,7 +183,7 @@ class EncounterPlayer:
                 "Select a number to take turn, or " +
                 "apply (d)amage or (h)ealing, (s)kip to next turn, or (q)uit: "
             )
-            callback = switcher.get(option)
+            callback = callback_map.get(option)
 
         return callback()
 


### PR DESCRIPTION
Added f string syntax and class __str__ methods to make class objects printable/formattable.

New CallbackMap class replaces OptionSwitcher
* takes a list of objects to pass as arguments to the callback action, rather than a number of options to generate
* takes `**kwargs` and attaches them to each `partial` function.